### PR TITLE
Spell the module name correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-Dist-Zilla-Plugin-AnnouncRelease*
+Dist-Zilla-Plugin-AnnounceRelease*
 .build
 *.sw*
 *~


### PR DESCRIPTION
Typo in .gitignore
